### PR TITLE
use 'family' config param as plugin_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Size and time metric units are bytes and milliseconds, respectively.
 
 ####Configuration parameters (defaults refer to values in g1gcstats.conf):
 - **`LogDir`**: directory to find GC logs in (REQUIRED: no default).
-- **`Family`**: qualifier, name for the cluster type the plugin is running on (`""`).
+- **`Family`**: plugin\_instance value for the cluster type the plugin is running on (`""`).
 - **`Verbose`**: if `true`, print verbose logging (`false`).
 - **`MeasureEdenAvg`**: if `true`, record and send mean Eden size (`true`).
 - **`MeasureTenuredAvg`**: if `true`, record and send mean Tenured (Old Gen) size (`true`).

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -42,7 +42,7 @@ def _mean_rounded(values):
 
 # signalfx-formatted family metric prefix:
 def _family_qual(family):
-  return family.lower().strip('. \t\n\r').replace(' ', '_') + '.' if family else ''
+  return family.lower().strip('. \t\n\r').replace(' ', '_') if family else ''
 
 class G1GCMetrics(object):
   def __init__(self, collectd, logdir=None, log_prefix="gc", family=None, eden=True, tenured=True, ihop_threshold=True, mixed_pause=True, young_pause=True, pause_max=True, pause_threshold=None, humongous_enabled=True, verbose=False):
@@ -236,12 +236,13 @@ class G1GCMetrics(object):
       value = metrics[metric]
       if value == None:
         continue
-      self.log_verbose('Sending value %s=%s' % (self.family+metric, value))
+      self.log_verbose('Sending value %s %s=%s' % (self.family, metric, value))
       
       data_type, type_instance = metric.split(".", 1)
       val = self.collectd.Values(plugin='g1gc')
       val.type = data_type
-      val.type_instance = self.family+type_instance
+      val.type_instance = type_instance
+      val.plugin_instance = self.family
       val.values = [value]
       val.dispatch()
 


### PR DESCRIPTION
Instead of prefixing "family" (cluster type) config onto metric name, use it as the collectd plugin_instance.
Should allow for use of more generic GC dashboards across several different cluster types.
