### PR TITLE
Full GC tracking

### DIFF
--- a/g1gcstats.conf
+++ b/g1gcstats.conf
@@ -17,6 +17,7 @@
     MeasureIHOPThreshold true
     MeasureMixedPause true
     MeasureYoungPause true
+    MeasureFullPause true
     MeasureMaxPause true
     LongPauseThreshold 1000
     CountHumongousObjects true

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -61,7 +61,7 @@ class G1GCMetrics(object):
     self.verbose = verbose
 
     self.prev_log = None
-    self.next_line = 0
+    self.log_seek = 0
     self.prev_gc_type = None
     self.current_metrics = {
         eden_avg    : None,
@@ -136,8 +136,9 @@ class G1GCMetrics(object):
     gc_lines = []
     f = open(logpath)
     try:
-      gc_lines = f.readlines()[self.next_line:]
-      self.next_line += len(gc_lines)
+      f.seek(log_seek)
+      gc_lines = f.readlines()
+      self.log_seek = f.tell()
     finally:
       f.close()
     if is_first_run:
@@ -209,7 +210,7 @@ class G1GCMetrics(object):
 
   def reset_log(self, logpath):
     self.prev_log = logpath
-    self.next_line = 0
+    self.log_seek = 0
     self.prev_gc_type = None
 
   def any_pause_metrics_enabled(self):


### PR DESCRIPTION
Use `f.tell()` and `f.seek()` for more memory-efficient GC log file reads.
Detect full GCs and record them separately from mixed and young GCs. Only send sum of full GC pause time(s), since we don't expect more than one per reporting cycle.
