### PR TITLE
re.search instead of re.match

### DIFF
--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-import os, re
+import os, re, sys, time
 
 # metric names:
 eden_avg    = 'gauge.g1gc.eden.size'
@@ -145,7 +145,12 @@ class G1GCMetrics(object):
       self.reset_log(logpath)
     gc_lines = []
     f = open(logpath)
+    inode= os.fstat(f.fileno()).st_ino
     try:
+      if  os.stat(logpath).st_ino != inode:
+          f.close()
+          f = open(logpath)
+          inode = os.fstat(f.fileno()).st_ino
       f.seek(self.log_seek)
       gc_lines = f.readlines()
       self.log_seek = f.tell()

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -150,7 +150,8 @@ class G1GCMetrics(object):
       if  os.stat(logpath).st_ino != inode:
           f.close()
           f = open(logpath)
-          inode = os.fstat(f.fileno()).st_ino
+          inode = os.fstat(f.fileno()).st_in
+          self.reset_log(logpath)
       f.seek(self.log_seek)
       gc_lines = f.readlines()
       self.log_seek = f.tell()

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -34,7 +34,7 @@ mem_pat = re.compile('([0-9\.]+)([BKMG])')
 mem_factors = { 'B':0, 'K':1, 'M':2, 'G':3 }
 
 def _to_bytes(mem_amt):
-  match = mem_pat.match(mem_amt)
+  match = mem_pat.search(mem_amt)
   if match:
     return int(float(match.group(1)) * 1024 ** mem_factors[match.group(2)])
   else:
@@ -168,7 +168,7 @@ class G1GCMetrics(object):
     match = None
     for line in gc_lines:
       if self.eden or self.tenured:
-        match = heap_pat.match(line)
+        match = heap_pat.search(line)
         if match:
           young_sz = _to_bytes(match.group(after_eden_cap)) + _to_bytes(match.group(after_survivor))
           if self.eden:
@@ -180,22 +180,22 @@ class G1GCMetrics(object):
             tenures.append(old_sz)
           continue
       if self.ihop_threshold:
-        match = threshold_pat.match(line)
+        match = threshold_pat.search(line)
         if match:
           threshold_bytes = int(match.group(1))
           self.log_verbose("recording tenured space threshold of %d bytes" % threshold_bytes)
           continue
       if self.mixed_pause or self.young_pause or self.full_pause:
-        match = gc_start_pat.match(line)
+        match = gc_start_pat.search(line)
         if match:
           self.prev_gc_type = match.group(1)
           continue
-        match = full_gc_pat.match(line)
+        match = full_gc_pat.search(line)
         if match:
           self.prev_gc_type = "full"
           continue
       if self.any_pause_metrics_enabled():
-        match = pause_pat.match(line)
+        match = pause_pat.search(line)
         if match:
           pause_ms = int(round(float(match.group(1)) * 1000))
           self.log_verbose("recording %d ms pause of type %s" % (pause_ms, self.prev_gc_type))
@@ -207,7 +207,7 @@ class G1GCMetrics(object):
             full_pauses.append(pause_ms)
           continue
       if self.humongous_enabled:
-        match = humongous_pat.match(line)
+        match = humongous_pat.search(line)
         if match:
           humongous_count += 1
           continue
@@ -237,11 +237,11 @@ class G1GCMetrics(object):
 
   def find_last_gc_type(self, gc_lines):
     for line in gc_lines:
-      match = gc_start_pat.match(line)
+      match = gc_start_pat.search(line)
       if match:
         self.prev_gc_type = match.group(1)
       else:
-        match = full_gc_pat.match(line)
+        match = full_gc_pat.search(line)
         if match:
           self.prev_gc_type = "full"
 

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -136,8 +136,13 @@ class G1GCMetrics(object):
         new_metrics = self.read_recent_data_from_log(gc_logs[-1])
         if new_metrics:
           self.dispatch_metrics(self.update_metrics(new_metrics))
+      else:
+        self.collectd.error('g1gc plugin: no gc_logs exiting')
+        sys.exit(1)
     else:
       self.collectd.warning('g1gc plugin: skipping because no log directory ("LogDir") has been configured')
+      sys.exit(1)
+
 
   def read_recent_data_from_log(self, logpath):
     is_first_run = self.prev_log == None
@@ -146,8 +151,9 @@ class G1GCMetrics(object):
     gc_lines = []
     try:
       f = open(logpath)
+      self.collectd.info('g1gc plugin: working')
     except:
-      sys.exit(1)
+      self.collectd.error('g1gc plugin: exiting')
     try:
       inode= os.fstat(f.fileno()).st_ino
       if  os.stat(logpath).st_ino != inode:

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -144,9 +144,12 @@ class G1GCMetrics(object):
     if logpath != self.prev_log:
       self.reset_log(logpath)
     gc_lines = []
-    f = open(logpath)
-    inode= os.fstat(f.fileno()).st_ino
     try:
+      f = open(logpath)
+    except:
+      sys.exit(1)
+    try:
+      inode= os.fstat(f.fileno()).st_ino
       if  os.stat(logpath).st_ino != inode:
           f.close()
           f = open(logpath)


### PR DESCRIPTION
re.match is anchored at the beginning of the string so thing string never matched.

example data:
[PSYoungGen: 1340267K->11925K(1364992K)] 1870488K->542669K(4161536K), 0.0161738 secs] [Times: user=0.06 sys=10.01, real=10.02 secs] 

regex:pause_pat = re.compile('\s*\[Times: user=[0-9\.]+ sys=[0-9\.]+, real=([0-9\.]+) secs')