### PR TITLE
Add support for java versions 9+, where the gc logging format changed dramatically

### DIFF
--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -49,7 +49,7 @@ def _family_qual(family):
   return family.lower().strip('. \t\n\r').replace(' ', '_') if family else ''
 
 class G1GCMetrics(object):
-  def __init__(self, collectd, logdir=None, log_prefix="gc", family=None, eden=True, tenured=True, ihop_threshold=True, mixed_pause=True, young_pause=True, full_pause=True, pause_max=True, pause_threshold=None, humongous_enabled=True, verbose=False):
+  def __init__(self, collectd, logdir=None, log_prefix="gc", family=None, eden=True, tenured=True, ihop_threshold=True, mixed_pause=True, young_pause=True, full_pause=True, pause_max=True, pause_threshold=None, humongous_enabled=True, verbose=False, skip_first=True):
     self.collectd = collectd
     self.logdir = logdir
     self.log_prefix = log_prefix
@@ -64,6 +64,7 @@ class G1GCMetrics(object):
     self.pause_threshold = pause_threshold
     self.humongous_enabled = humongous_enabled
     self.verbose = verbose
+    self.skip_first = skip_first
 
     self.prev_log = None
     self.log_seek = 0
@@ -152,7 +153,7 @@ class G1GCMetrics(object):
       self.log_seek = f.tell()
     finally:
       f.close()
-    if is_first_run:
+    if is_first_run and self.skip_first:
       # don't process full log (may have restarted recently, don't want to double-count
       # instead, just run through the existing GC log, find type of the last GC (for next run)
       self.find_last_gc_type(gc_lines)
@@ -317,7 +318,7 @@ if __name__ == '__main__':
 
   from time import sleep
   collectd = CollectdMock('g1gc')
-  gc = G1GCMetrics(collectd, logdir=args.log_dir, pause_threshold=1000, verbose=True)
+  gc = G1GCMetrics(collectd, logdir=args.log_dir, pause_threshold=1000, verbose=True, skip_first=False)
   gc.read_callback()
   for i in range (0,2):
     sleep(60)

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -2,6 +2,8 @@
 import os, re
 import argparse
 
+MEGABYTES = 1024*1024
+
 # metric names:
 eden_avg    = 'gauge.g1gc.eden.size'
 tenured_avg = 'gauge.g1gc.tenured.size'
@@ -16,19 +18,216 @@ max_pause   = 'gauge.g1gc.pause.time.max'
 long_pause  = 'counter.g1gc.longpause.count'
 humongous   = 'counter.g1gc.humongous.count'
 
-# G1GC log regexes:
-before_after = '([0-9\.]+[BKMG])->([0-9\.]+[BKMG])'
-before_after_wcap = '([0-9\.]+[BKMG])\(([0-9\.]+[BKMG])\)->([0-9\.]+[BKMG])\(([0-9\.]+[BKMG])\)'
 
-heap_pat = re.compile('\s*\[Eden: %s Survivors: %s Heap: %s' % (before_after_wcap, before_after, before_after_wcap))
-threshold_pat = re.compile('.*threshold: ([0-9]+) bytes .*, source: end of GC\]') # only need most recent
-gc_start_pat = re.compile('[0-9T\-\:\.\+]* [0-9\.]*: \[GC pause \(G1 Evacuation Pause\) \((young|mixed)\)') # use previous occurrence of this to track pause types
-full_gc_pat = re.compile('[0-9T\-\:\.\+]* [0-9\.]*: \[Full GC ')
-pause_pat = re.compile('\s*\[Times: user=[0-9\.]+ sys=[0-9\.]+, real=([0-9\.]+) secs')
-humongous_pat = re.compile('.* source: concurrent humongous allocation\]$')
+class Parser(object):
+  def __init__(self, config):
+    self.config = config
+    self.prev_gc_type = config.prev_gc_type
+    self.edens = []
+    self.tenures = []
+    self.threshold_bytes = 0
+    self.mixed_pauses = []
+    self.young_pauses = []
+    self.full_pauses = []
+    self.humongous_count = 0
 
-# groups for heap pat:
-before_eden_sz, before_eden_cap, after_eden_sz, after_eden_cap, before_survivor, after_survivor, before_heap_sz, before_heap_cap, after_heap_sz, after_heap_cap = range(1,11)
+  def parse_heap(self, line):
+      raise NotImplementedError('parse_heap not implemented')
+
+  def parse_ihop_threshold(self, line):
+    raise NotImplementedError('parse_ihop_threshold not implemented')
+
+  def parse_gc_start(self, line):
+    raise NotImplementedError('parse_gc_start not implemented')
+
+  def parse_pause_time(self, line):
+    raise NotImplementedError('parse_pause_time not implemented')
+
+  def parse_humongous_alloc(self, line):
+    raise NotImplementedError('parse_humongous_alloc not implemented')
+
+  def find_last_gc_type(self, lines):
+    for line in lines:
+      result = self.parse_gc_start(line)
+      if result:
+        self.prev_gc_type = result
+        self.config.prev_gc_type = result
+
+  def parse(self, line):
+    if self.config.eden or self.config.tenured:
+      result = self.parse_heap(line)
+      if result:
+        if self.config.eden:
+          self.config.log_verbose("recording Eden size of %d bytes" % result['young'])
+          self.edens.append(result['young'])
+        if self.config.tenured:
+          self.config.log_verbose("recording Tenured size of %d bytes" % result['old'])
+          self.tenures.append(result['old'])
+        return
+
+    if self.config.ihop_threshold:
+      result = self.parse_ihop_threshold(line)
+      if result is not None:
+        self.threshold_bytes = result
+        self.config.log_verbose("recording tenured space threshold of %d bytes" % self.threshold_bytes)
+        return
+
+    if self.config.mixed_pause or self.config.young_pause or self.config.full_pause:
+      result = self.parse_gc_start(line)
+      if result:
+        self.prev_gc_type = result
+        self.config.prev_gc_type = result
+        return
+
+    # assumes that timings come after the gc start line
+    if self.config.any_pause_metrics_enabled():
+      result = self.parse_pause_time(line)
+      if result is not None:
+        if self.prev_gc_type == 'mixed':
+          self.mixed_pauses.append(result)
+        elif self.prev_gc_type == 'young':
+          self.young_pauses.append(result)
+        else:
+          self.full_pauses.append(result)
+        return
+
+    if self.config.humongous_enabled:
+      result = self.parse_humongous_alloc(line)
+      if result:
+        self.humongous_count += 1
+
+  def to_metrics(self):
+    if self.config.pause_max:
+      max_pause_val = max([0] + self.mixed_pauses + self.young_pauses + self.full_pauses)
+    else:
+      max_pause_val = None
+
+    if self.config.pause_threshold:
+      long_pause_val = len(filter(lambda y: y > self.config.pause_threshold, self.mixed_pauses + self.young_pauses + self.full_pauses))
+    else:
+      long_pause_val = None
+
+    return {
+        eden_avg    : _mean_rounded(self.edens) if (self.config.eden and self.edens) else None,
+        tenured_avg : _mean_rounded(self.tenures) if (self.config.tenured and self.tenures) else None,
+        threshold   : self.threshold_bytes if (self.config.ihop_threshold and self.threshold_bytes) else None,
+        mixed_count : len(self.mixed_pauses) if self.config.mixed_pause else None,
+        mixed_total : sum(self.mixed_pauses) if self.config.mixed_pause else None,
+        young_count : len(self.young_pauses) if self.config.young_pause else None,
+        young_total : sum(self.young_pauses) if self.config.young_pause else None,
+        full_count  : len(self.full_pauses) if self.config.full_pause else None,
+        full_total  : sum(self.full_pauses) if self.config.full_pause else None,
+        max_pause   : max_pause_val,
+        long_pause  : long_pause_val,
+        humongous   : self.humongous_count if self.config.humongous_enabled else None
+    }
+
+
+class Java8Parser(Parser):
+  before_after = '([0-9\.]+[BKMG])->([0-9\.]+[BKMG])'
+  before_after_wcap = '([0-9\.]+[BKMG])\(([0-9\.]+[BKMG])\)->([0-9\.]+[BKMG])\(([0-9\.]+[BKMG])\)'
+  heap_pat = re.compile('\s*\[Eden: %s Survivors: %s Heap: %s' % (before_after_wcap, before_after, before_after_wcap))
+  before_eden_sz, before_eden_cap, after_eden_sz, after_eden_cap, before_survivor, after_survivor, before_heap_sz, before_heap_cap, after_heap_sz, after_heap_cap = range(1,11)
+
+  threshold_pat = re.compile('.*threshold: ([0-9]+) bytes .*, source: end of GC\]') # only need most recent
+  gc_start_pat = re.compile('[0-9T\-\:\.\+]* [0-9\.]*: \[GC pause \(G1 Evacuation Pause\) \((young|mixed)\)') # use previous occurrence of this to track pause types
+  full_gc_pat = re.compile('[0-9T\-\:\.\+]* [0-9\.]*: \[Full GC ')
+  pause_pat = re.compile('\s*\[Times: user=[0-9\.]+ sys=[0-9\.]+, real=([0-9\.]+) secs')
+  humongous_pat = re.compile('.* source: concurrent humongous allocation\]$')
+
+  def __init__(self, config):
+    super(Java8Parser, self).__init__(config)
+
+  def parse_heap(self, line):
+      match = self.heap_pat.match(line)
+      if match:
+        young_sz = _to_bytes(match.group(self.after_eden_cap)) + _to_bytes(match.group(self.after_survivor))
+        old_sz = _to_bytes(match.group(self.after_heap_sz)) - _to_bytes(match.group(self.after_survivor))
+        return {'young': young_sz, 'old': old_sz}
+      return None
+
+  def parse_ihop_threshold(self, line):
+    match = self.threshold_pat.match(line)
+    if match:
+      return int(match.group(1))
+    return None
+
+  def parse_gc_start(self, line):
+    match = self.gc_start_pat.match(line)
+    if match:
+      return match.group(1)
+    match = self.full_gc_pat.match(line)
+    if match:
+      return "full"
+    return None
+
+  def parse_pause_time(self, line):
+    match = self.pause_pat.match(line)
+    if match:
+      return int(round(float(match.group(1)) * 1000))
+    return None
+
+  def parse_humongous_alloc(self, line):
+    return self.humongous_pat.match(line)
+
+
+class Java9PlusParser(Parser):
+  regions_pat = re.compile(r'.*GC\(\d+\) (Eden|Survivor|Old|Humongous) regions: (\d+)->(\d+)(?:\((\d+)\))?')
+  threshold_pat = re.compile(r'.*GC\(\d+\) .*threshold: ([0-9]+)B \([\d\.]+\) source: end of GC') # only need most recent
+  gc_start_pat = re.compile(r'.*GC\(\d+\) Pause (Young|Mixed|Full)')
+  pause_pat = re.compile(r'.*GC\(\d+\) User=[0-9\.]+s Sys=[0-9\.]+s Real=([0-9\.]+)s')
+  humongous_pat = re.compile(r'.*GC\(\d+\) .* source: concurrent humongous allocation$')
+
+  def __init__(self, config):
+    super(Java9PlusParser, self).__init__(config)
+
+    # used to collect multi-line heap sizing metrics below, will be reset after each block
+    self.young_regions = 0
+
+  def parse_heap(self, line):
+      match = self.regions_pat.match(line)
+      if match:
+        region_type = match.group(1)
+
+        if region_type == 'Eden' or region_type == 'Survivor':
+          # we add post_gc cap for eden and survivor together to get total young size
+          # they come one after another on separate lines
+          self.young_regions += int(match.group(4))
+        elif region_type == 'Old':
+          # after eden/survivor comes old, and here we can report the full result
+          young_sz = self.config.region_size_mb * MEGABYTES * self.young_regions
+
+          # old doesn't have a cap, so just use post-gc amount
+          old_sz = self.config.region_size_mb * MEGABYTES * int(match.group(3))
+
+          # reset young_regions for next gc
+          self.young_regions = 0
+
+          return {'young': young_sz, 'old': old_sz}
+
+      return None
+
+  def parse_ihop_threshold(self, line):
+    match = self.threshold_pat.match(line)
+    if match:
+      return int(match.group(1))
+    return None
+
+  def parse_gc_start(self, line):
+    match = self.gc_start_pat.match(line)
+    if match:
+      return match.group(1).lower()
+    return None
+
+  def parse_pause_time(self, line):
+    match = self.pause_pat.match(line)
+    if match:
+      return int(round(float(match.group(1)) * 1000))
+    return None
+
+  def parse_humongous_alloc(self, line):
+    return self.humongous_pat.match(line)
+
 
 # memory string conversion to bytes:
 mem_pat = re.compile('([0-9\.]+)([BKMG])')
@@ -49,11 +248,13 @@ def _family_qual(family):
   return family.lower().strip('. \t\n\r').replace(' ', '_') if family else ''
 
 class G1GCMetrics(object):
-  def __init__(self, collectd, logdir=None, log_prefix="gc", family=None, eden=True, tenured=True, ihop_threshold=True, mixed_pause=True, young_pause=True, full_pause=True, pause_max=True, pause_threshold=None, humongous_enabled=True, verbose=False, skip_first=True):
+  def __init__(self, collectd, jvm_version='8', logdir=None, log_prefix="gc", family=None, region_size_mb=1, eden=True, tenured=True, ihop_threshold=True, mixed_pause=True, young_pause=True, full_pause=True, pause_max=True, pause_threshold=None, humongous_enabled=True, verbose=False, skip_first=True):
     self.collectd = collectd
+    self.jvm_version = jvm_version
     self.logdir = logdir
     self.log_prefix = log_prefix
     self.family = _family_qual(family)
+    self.region_size_mb = region_size_mb
     self.eden = eden
     self.tenured = tenured
     self.ihop_threshold = ihop_threshold
@@ -87,12 +288,16 @@ class G1GCMetrics(object):
   def configure_callback(self, conf):
     """called by collectd to configure the plugin. This is called only once"""
     for node in conf.children:
-      if node.key == 'LogDir':
+      if node.key == 'JvmVersion':
+        self.jvm_version = node.values[0]
+      elif node.key == 'LogDir':
         self.logdir = node.values[0]
       elif node.key == 'LogPrefix':
         self.log_prefix = node.values[0]
       elif node.key == 'Family':
         self.family = _family_qual(node.values[0])
+      elif node.key == 'RegionSizeMB':
+        self.region_size_mb = int(node.values[0])
       elif node.key == 'MeasureEdenAvg':
         self.eden = bool(node.values[0])
       elif node.key == 'MeasureTenuredAvg':
@@ -141,6 +346,12 @@ class G1GCMetrics(object):
     else:
       self.collectd.warning('g1gc plugin: skipping because no log directory ("LogDir") has been configured')
 
+  def get_parser(self):
+    if str(self.jvm_version) == '8':
+      return Java8Parser(self)
+    # default to this because it actually works for all 9+
+    return Java9PlusParser(self)
+
   def read_recent_data_from_log(self, logpath):
     is_first_run = self.prev_log == None
     if logpath != self.prev_log:
@@ -153,81 +364,20 @@ class G1GCMetrics(object):
       self.log_seek = f.tell()
     finally:
       f.close()
+
+    parser = self.get_parser()
     if is_first_run and self.skip_first:
       # don't process full log (may have restarted recently, don't want to double-count
       # instead, just run through the existing GC log, find type of the last GC (for next run)
-      self.find_last_gc_type(gc_lines)
+      parser.find_last_gc_type(gc_lines)
       self.log_verbose("skipping metrics dispatch, since this is the first read since plugin restart")
       return {}
+
     # else, read metrics from logs as usual
-    edens = []
-    tenures = []
-    threshold_bytes = 0
-    mixed_pauses = []
-    young_pauses = []
-    full_pauses = []
-    humongous_count = 0
-    match = None
     for line in gc_lines:
-      if self.eden or self.tenured:
-        match = heap_pat.match(line)
-        if match:
-          young_sz = _to_bytes(match.group(after_eden_cap)) + _to_bytes(match.group(after_survivor))
-          if self.eden:
-            self.log_verbose("recording Eden size of %d bytes" % young_sz)
-            edens.append(young_sz)
-          if self.tenured:
-            old_sz = _to_bytes(match.group(after_heap_sz)) - _to_bytes(match.group(after_survivor))
-            self.log_verbose("recording Tenured size of %d bytes" % old_sz)
-            tenures.append(old_sz)
-          continue
-      if self.ihop_threshold:
-        match = threshold_pat.match(line)
-        if match:
-          threshold_bytes = int(match.group(1))
-          self.log_verbose("recording tenured space threshold of %d bytes" % threshold_bytes)
-          continue
-      if self.mixed_pause or self.young_pause or self.full_pause:
-        match = gc_start_pat.match(line)
-        if match:
-          self.prev_gc_type = match.group(1)
-          continue
-        match = full_gc_pat.match(line)
-        if match:
-          self.prev_gc_type = "full"
-          continue
-      if self.any_pause_metrics_enabled():
-        match = pause_pat.match(line)
-        if match:
-          pause_ms = int(round(float(match.group(1)) * 1000))
-          self.log_verbose("recording %d ms pause of type %s" % (pause_ms, self.prev_gc_type))
-          if self.prev_gc_type == 'mixed':
-            mixed_pauses.append(pause_ms)
-          elif self.prev_gc_type == 'young':
-            young_pauses.append(pause_ms)
-          else:
-            full_pauses.append(pause_ms)
-          continue
-      if self.humongous_enabled:
-        match = humongous_pat.match(line)
-        if match:
-          humongous_count += 1
-          continue
-    metrics = { 
-        eden_avg    : _mean_rounded(edens) if (self.eden and edens) else None,
-        tenured_avg : _mean_rounded(tenures) if (self.tenured and tenures) else None,
-        threshold   : threshold_bytes if (self.ihop_threshold and threshold_bytes) else None,
-        mixed_count : len(mixed_pauses) if self.mixed_pause else None,
-        mixed_total : sum(mixed_pauses) if self.mixed_pause else None,
-        young_count : len(young_pauses) if self.young_pause else None,
-        young_total : sum(young_pauses) if self.young_pause else None,
-        full_count  : len(full_pauses) if self.full_pause else None,
-        full_total  : sum(full_pauses) if self.full_pause else None,
-        max_pause   : max(mixed_pauses + young_pauses + full_pauses if mixed_pauses or young_pauses or full_pauses else [0]) if self.pause_max else None,
-        long_pause  : len(filter(lambda y: y > self.pause_threshold, mixed_pauses + young_pauses + full_pauses)) if self.pause_threshold else None,
-        humongous   : humongous_count if self.humongous_enabled else None
-        }
-    return metrics
+      parser.parse(line)
+
+    return parser.to_metrics()
 
   def reset_log(self, logpath):
     self.prev_log = logpath
@@ -236,16 +386,6 @@ class G1GCMetrics(object):
 
   def any_pause_metrics_enabled(self):
     return self.mixed_pause or self.young_pause or self.full_pause or self.pause_max or self.pause_threshold
-
-  def find_last_gc_type(self, gc_lines):
-    for line in gc_lines:
-      match = gc_start_pat.match(line)
-      if match:
-        self.prev_gc_type = match.group(1)
-      else:
-        match = full_gc_pat.match(line)
-        if match:
-          self.prev_gc_type = "full"
 
   def update_metrics(self, new_metrics):
     """updates metrics from last run with new metrics, to make current"""
@@ -314,11 +454,12 @@ class CollectdValuesMock(object):
 if __name__ == '__main__':
   parser = argparse.ArgumentParser(description='Parse gc logs into collectd metrics - debug mode')
   parser.add_argument('--log-dir', '-d', metavar='PATH', default='/tmp/logs', help='path to directory with gc logs in them')
+  parser.add_argument('--jvm-version', '-j', metavar='VERSION', default=8, help='Which version of the jvm to run against', type=int)
   args = parser.parse_args()
 
   from time import sleep
   collectd = CollectdMock('g1gc')
-  gc = G1GCMetrics(collectd, logdir=args.log_dir, pause_threshold=1000, verbose=True, skip_first=False)
+  gc = G1GCMetrics(collectd, jvm_version=args.jvm_version, logdir=args.log_dir, pause_threshold=1000, verbose=True, skip_first=False)
   gc.read_callback()
   for i in range (0,2):
     sleep(60)

--- a/g1gcstats.py
+++ b/g1gcstats.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import os, re
+import argparse
 
 # metric names:
 eden_avg    = 'gauge.g1gc.eden.size'
@@ -310,9 +311,13 @@ class CollectdValuesMock(object):
     return "<CollectdValues %s>" % (' '.join(attrs))
 
 if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Parse gc logs into collectd metrics - debug mode')
+  parser.add_argument('--log-dir', '-d', metavar='PATH', default='/tmp/logs', help='path to directory with gc logs in them')
+  args = parser.parse_args()
+
   from time import sleep
   collectd = CollectdMock('g1gc')
-  gc = G1GCMetrics(collectd, logdir='/tmp/logs/', pause_threshold=1000, verbose=True)
+  gc = G1GCMetrics(collectd, logdir=args.log_dir, pause_threshold=1000, verbose=True)
   gc.read_callback()
   for i in range (0,2):
     sleep(60)


### PR DESCRIPTION
In order to support this I added a new Parser class which gets called for every read line. The Parser class calls various abstract methods which are implemented by Java8Parser and Java9PlusParser.

Beyond massive formatting changes, one semantic change in the new format is they no longer print heap sizes. Instead they print number of regions, for example:

In java8:
```
[Eden: 1744.0M(1744.0M)->0.0B(1744.0M) Survivors: 16384.0K->16384.0K Heap: 14379.5M(16384.0M)->12640.6M(16384.0M)]
```

In java11:

```
[2021-12-08T10:36:21.602+0000][1692223.304s][info ][gc,heap       ] GC(22629) Eden regions: 152->0(152)
[2021-12-08T10:36:21.602+0000][1692223.304s][info ][gc,heap       ] GC(22629) Survivor regions: 1->1(20)
[2021-12-08T10:36:21.602+0000][1692223.304s][info ][gc,heap       ] GC(22629) Old regions: 383->383
[2021-12-08T10:36:21.602+0000][1692223.304s][info ][gc,heap       ] GC(22629) Humongous regions: 18->18
```

One can enable trace logging with `-Xlog:gc+heap=trace`, which adds a best effort heap estimation but always prints `0K -> 0K` for eden. So it seemed best to not bother with that, since it doesn't give us the whole picture. Instead, one can configure RegionSizeMB which will multiply these region counts by that amount to create heap size estimates. The default value for that is 1, resulting in `gauge.g1gc.eden.size`, etc being reported as number of regions instead of heap bytes. If you want estimated heap bytes you should set RegionSizeMB equal to `-XX:G1HeapRegionSize`. I think this estimation will be not be perfect, as that seems to be the reason the heap sizes were removed in the first place: https://bugs.openjdk.java.net/browse/JDK-8148736.

There is a lot of cleanup that could happen here and it might even be interesting to start reporting on some of the new data available in the logs (such as humongous regions). But for now I really just want to get this to work while retaining as much of the original behavior as possible.

I've tested this on a single java8 gc log and java 11 gc log. I'm going to test on a few more java8 gc logs to ensure equivalent output and then iterate from there in followup PRs as necessary.